### PR TITLE
Fix disappearing notes

### DIFF
--- a/js/keydown.js
+++ b/js/keydown.js
@@ -152,9 +152,12 @@ function selectShiftedFretNotes(getCurrentFretAndFretToSelect) {
     // Shift all the selected notes to the left
     // Deselect all the selected notes and select the notes in the same index one container to the left
     selectedNotes = document.querySelectorAll('.selected');
+
+    // Deselect the current note
+    selectedNotes.forEach(noteElement => { noteElement.classList.remove('selected') });
+
+    // Select the note in the same index one container to the left
     selectedNotes.forEach(noteElement => {
-        // Deselect the current note
-        noteElement.classList.remove('selected');
         var { noteElementParent: fretCurrent, noteElementParentSibling: fretToSelect } = getCurrentFretAndFretToSelect(noteElement);
 
         // Get the note at the same index in the previous container


### PR DESCRIPTION
Previously, already selected notes were being removed even if they were supposed to be selected after the translation. This PR ensures that the notes are first deselected and then shifted in two independent for loops.

#10