### PR TITLE
Fix translation first last frets

### DIFF
--- a/js/keydown.js
+++ b/js/keydown.js
@@ -158,53 +158,75 @@ function selectShiftedFretNotes(getCurrentFretAndFretToSelect) {
 
     // Select the note in the same index one container to the left
     selectedNotes.forEach(noteElement => {
-        var { noteFret: fretCurrent, noteFretSibling: fretToSelect } = getCurrentFretAndFretToSelect(noteElement);
+        var { noteFret: fretCurrent, noteFretSiblings: fretsToSelect } = getCurrentFretAndFretToSelect(noteElement);
 
         // Get the note at the same index in the previous container
         const index = Array.from(fretCurrent.children).indexOf(noteElement);
-        const newNote = fretToSelect.children[index];
+        fretsToSelect.forEach(fretToSelect => {
+            const newNote = fretToSelect.children[index];
 
-        // If there is a note at the same index in the previous container
-        if (newNote !== undefined) {
-            // Select the note
-            newNote.classList.add('selected');
-        }
+            // If there is a note at the same index in the previous container
+            if (newNote !== undefined) {
+                // Select the note
+                newNote.classList.add('selected');
+            }
+        });
     });
 }
 
 
 function getCurrentFretAndFretToTheLeft(noteElement) {
     // Get the previous container
-    const noteFret = noteElement.parentElement;
-    let noteFretSibling = noteFret.previousElementSibling;
+    let noteFret = noteElement.parentElement;
+    let noteFretSiblings = [];  // Multiple siblings if the current fret is the 12th fret
 
-    // If there is no previous container, select the last container
-    if (noteFretSibling === null) {
-        noteFretSibling = noteFret.parentElement.lastElementChild;
+    // Get one fret to the left
+    let noteFretSibling = noteFret.previousElementSibling;
+    if (noteFretSibling !== null) {
+        // If there is a previous fret, then append it to the list of siblings
+        noteFretSiblings.push(noteFretSibling);
+    }
+
+    const guitarNeck = noteFret.parentElement;
+
+    // If the current fret is the 1st fret, then shift note to the 11th fret
+    if (Array.from(guitarNeck.children).indexOf(noteFret) === 0) {
+        // Get 12th fret and append it to the list of siblings
+        noteFretSibling = guitarNeck.children[11];
+        noteFretSiblings.push(noteFretSibling);
     }
 
     return {
-        noteFret,
-        noteFretSibling
+        noteFret: noteFret,
+        noteFretSiblings: noteFretSiblings
     };
 }
 
 
 function getCurrentFretAndFretToTheRight(noteElement) {
     // Get the next container
-    const noteFret = noteElement.parentElement;
-    let noteFretSibling = noteFret.nextElementSibling;
+    let noteFret = noteElement.parentElement;
+    let noteFretSiblings = [];  // Multiple siblings if the current fret is the 12th fret
 
-    // If there is no next container, select the first container and update the "current" fret
-    if (noteFretSibling === null) {
-        noteFretSibling = noteFret.parentElement.firstElementChild;
-        // TODO(LM): Take the currentFretNum % numFretsToShow to get the correct current fret
-        // Get the current fret number
+    // Get one fret to the right
+    let noteFretSibling = noteFret.nextElementSibling;
+    if (noteFretSibling !== null) {
+        //  If there is a next fret, then append it to the list of siblings
+        noteFretSiblings.push(noteFretSibling);
+    }
+
+    const guitarNeck = noteFret.parentElement;
+
+    // If the current fret is the 12th fret, then shift note to both the 13th and 1st frets
+    if (Array.from(guitarNeck.children).indexOf(noteFret) === 11) {
+        // Get 1st fret and append it to the list of siblings
+        noteFretSibling = guitarNeck.firstElementChild;
+        noteFretSiblings.push(noteFretSibling);
 
     }
 
     return {
         noteFret: noteFret,
-        noteFretSibling: noteFretSibling
+        noteFretSiblings: noteFretSiblings
     };
 }

--- a/js/keydown.js
+++ b/js/keydown.js
@@ -158,7 +158,7 @@ function selectShiftedFretNotes(getCurrentFretAndFretToSelect) {
 
     // Select the note in the same index one container to the left
     selectedNotes.forEach(noteElement => {
-        var { noteElementParent: fretCurrent, noteElementParentSibling: fretToSelect } = getCurrentFretAndFretToSelect(noteElement);
+        var { noteFret: fretCurrent, noteFretSibling: fretToSelect } = getCurrentFretAndFretToSelect(noteElement);
 
         // Get the note at the same index in the previous container
         const index = Array.from(fretCurrent.children).indexOf(noteElement);
@@ -175,33 +175,36 @@ function selectShiftedFretNotes(getCurrentFretAndFretToSelect) {
 
 function getCurrentFretAndFretToTheLeft(noteElement) {
     // Get the previous container
-    const noteElementParent = noteElement.parentElement;
-    let noteElementParentSibling = noteElementParent.previousElementSibling;
+    const noteFret = noteElement.parentElement;
+    let noteFretSibling = noteFret.previousElementSibling;
 
     // If there is no previous container, select the last container
-    if (noteElementParentSibling === null) {
-        noteElementParentSibling = noteElementParent.parentElement.lastElementChild;
+    if (noteFretSibling === null) {
+        noteFretSibling = noteFret.parentElement.lastElementChild;
     }
 
     return {
-        noteElementParent,
-        noteElementParentSibling
+        noteFret,
+        noteFretSibling
     };
 }
 
 
 function getCurrentFretAndFretToTheRight(noteElement) {
     // Get the next container
-    const noteElementParent = noteElement.parentElement;
-    let noteElementParentSibling = noteElementParent.nextElementSibling;
+    const noteFret = noteElement.parentElement;
+    let noteFretSibling = noteFret.nextElementSibling;
 
-    // If there is no next container, select the first container
-    if (noteElementParentSibling === null) {
-        noteElementParentSibling = noteElementParent.parentElement.firstElementChild;
+    // If there is no next container, select the first container and update the "current" fret
+    if (noteFretSibling === null) {
+        noteFretSibling = noteFret.parentElement.firstElementChild;
+        // TODO(LM): Take the currentFretNum % numFretsToShow to get the correct current fret
+        // Get the current fret number
+
     }
 
     return {
-        noteElementParent,
-        noteElementParentSibling
+        noteFret: noteFret,
+        noteFretSibling: noteFretSibling
     };
 }


### PR DESCRIPTION
Previously, a simple circular shift was being used for left/right translation without taking into account the divisibility by number of unique notes (see #12). This PR loops the 12th fret shifted right back to 1 (while still highlighting 13), and loops the 1st fret shifted left back to 12. 

We notice that while notes are regenerative if shifting to the right (due to 12 looping back to 1 while still highlighting 13), the notes are able to shift off screen when shifting left and essentially disappear. 

While this PR is a step towards "correct" functionality, it is becoming clearer that perhaps the more correct functionality would be take away the regenerative shifting in normal mode and only handle regenerative shifting (in both direction) when in "scale mode" (discussed in #9).

