### PR TITLE
Toggle reversed fretboard

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -59,6 +59,11 @@ body {
     justify-content: space-between
 }
 
+.guitarNeck.reverse {
+    flex-direction: row-reverse;
+    /* Reversed: right-to-left */
+}
+
 .guitarFret {
     height: 100%;
     display: flex;

--- a/js/keydown.js
+++ b/js/keydown.js
@@ -96,16 +96,21 @@ document.addEventListener('keydown', event => {
         case "KeyR":
             // R key
             // Reverse the direction of the fretboard
-            const guitarNeckElement = document.querySelector('.guitarNeck');
             guitarNeckElement.classList.toggle('reverse');
         case "ArrowLeft":
             // Left arrow key
-            selectShiftedFretNotes(getCurrentFretAndLowerFret);
+            // Check if guitarNeckElement has class 'reverse'
+            getCurrentFretAndFretToSelect = guitarNeckElement.classList.contains('reverse') ?
+                getCurrentFretAndHigherFret : getCurrentFretAndLowerFret
+            selectShiftedFretNotes(getCurrentFretAndFretToSelect);
             updateLegend();
             break;
         case "ArrowRight":
             // Left arrow key
-            selectShiftedFretNotes(getCurrentFretAndHigherFret);
+            // Check if guitarNeckElement has class 'reverse'
+            getCurrentFretAndFretToSelect = guitarNeckElement.classList.contains('reverse') ?
+                getCurrentFretAndLowerFret : getCurrentFretAndHigherFret
+            selectShiftedFretNotes(getCurrentFretAndFretToSelect);
             updateLegend();
             break;
     }

--- a/js/keydown.js
+++ b/js/keydown.js
@@ -93,14 +93,19 @@ document.addEventListener('keydown', event => {
                 toggleSelectedNotes(gNotes);
             }
             break;
+        case "KeyR":
+            // R key
+            // Reverse the direction of the fretboard
+            const guitarNeckElement = document.querySelector('.guitarNeck');
+            guitarNeckElement.classList.toggle('reverse');
         case "ArrowLeft":
             // Left arrow key
-            selectShiftedFretNotes(getCurrentFretAndFretToTheLeft);
+            selectShiftedFretNotes(getCurrentFretAndLowerFret);
             updateLegend();
             break;
         case "ArrowRight":
             // Left arrow key
-            selectShiftedFretNotes(getCurrentFretAndFretToTheRight);
+            selectShiftedFretNotes(getCurrentFretAndHigherFret);
             updateLegend();
             break;
     }
@@ -175,7 +180,7 @@ function selectShiftedFretNotes(getCurrentFretAndFretToSelect) {
 }
 
 
-function getCurrentFretAndFretToTheLeft(noteElement) {
+function getCurrentFretAndLowerFret(noteElement) {
     // Get the previous container
     let noteFret = noteElement.parentElement;
     let noteFretSiblings = [];  // Multiple siblings if the current fret is the 12th fret
@@ -203,7 +208,7 @@ function getCurrentFretAndFretToTheLeft(noteElement) {
 }
 
 
-function getCurrentFretAndFretToTheRight(noteElement) {
+function getCurrentFretAndHigherFret(noteElement) {
     // Get the next container
     let noteFret = noteElement.parentElement;
     let noteFretSiblings = [];  // Multiple siblings if the current fret is the 12th fret


### PR DESCRIPTION
The original fretboard was set-up for a right-strumming-hand player (see #8). This PR flips the fretboard around for left-strumming-hand players using the "r" key for "reversed".